### PR TITLE
Fix: Define executable product for Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,15 +2,15 @@
 import PackageDescription
 
 let package = Package(
-    name: "KtranslateCore",
+    name: "Ktranslate", // Changed
     platforms: [
-        .macOS(.v13), // Updated
+        .macOS(.v13),
         .iOS(.v15)
     ],
     products: [
-        .library(
-            name: "KtranslateCore",
-            targets: ["KtranslateCore"])
+        .executable( // Changed to executable
+            name: "Ktranslate", // Product name
+            targets: ["Ktranslate"]) // Points to the executable target
     ],
     dependencies: [
         // No external dependencies yet
@@ -19,14 +19,16 @@ let package = Package(
         .target(
             name: "KtranslateCore",
             dependencies: [],
-            path: "Ktranslate", // Point to the existing folder where all .swift files are
-            exclude: ["KtranslateApp.swift"]
+            path: "Ktranslate",
+            exclude: ["KtranslateApp.swift", "Info.plist"], // Ensure KtranslateApp.swift is excluded
+            sources: nil // Let Swift discover sources, respecting excludes
+        ),
+        .executableTarget( // New executable target
+            name: "Ktranslate", // Executable target name
+            dependencies: ["KtranslateCore"], // Depends on the library
+            path: "Ktranslate",
+            sources: ["KtranslateApp.swift"] // Explicitly include KtranslateApp.swift
         )
-        // We can add a test target later:
-        // .testTarget(
-        // name: "KtranslateCoreTests",
-        // dependencies: ["KtranslateCore"],
-        // path: "KtranslateTests" // Assuming tests will be in KtranslateTests folder
-        // )
+        // Test target can be added later
     ]
 )


### PR DESCRIPTION
The project was previously configured to produce only a library, leading to an 'error: no executable product available' when you attempted to run the application using 'swift run'.

This commit modifies the Package.swift file to:
1. Rename the package to 'Ktranslate'.
2. Define an executable target named 'Ktranslate' which uses Ktranslate/KtranslateApp.swift as its entry point and depends on the 'KtranslateCore' library.
3. Define an executable product named 'Ktranslate' that points to this new executable target.
4. Adjust the 'KtranslateCore' library target to correctly exclude KtranslateApp.swift.

These changes allow the project to be built and run as an executable application.